### PR TITLE
Add full Streamlit evaluation workflow

### DIFF
--- a/app/pages/2_eval_setup.py
+++ b/app/pages/2_eval_setup.py
@@ -1,6 +1,333 @@
+"""
+Page 2: Evaluation Setup - Data Upload and Scoring Configuration
+"""
 import streamlit as st
+import pandas as pd
+from typing import List, Dict, Any
+import asyncio
+from io import StringIO
 
-st.title("Evaluation Setup")
-upload = st.file_uploader("CSV File")
-if upload:
-    st.success("File uploaded")
+from core.ingestion import load_evaluation_data, validate_csv_columns
+from core.generation import generate_outputs
+from core.evaluation import run_evaluation
+from core.data_models import EvaluationItem, EvaluationMode
+from core.scoring import get_available_scorers
+from services.llm_clients import create_llm_client
+
+st.set_page_config(page_title="Evaluation Setup", page_icon="📄", layout="wide")
+
+st.title("📄 Evaluation Setup")
+st.markdown("Upload data, configure evaluation mode, and select scoring methods.")
+
+# Check prerequisites
+if not st.session_state.api_keys:
+    st.warning("⚠️ Please configure API keys in the System Configuration page first.")
+    st.stop()
+
+# Evaluation Mode Selection
+st.header("1. Select Evaluation Mode")
+mode = st.radio(
+    "Choose how you want to evaluate:",
+    [EvaluationMode.EVALUATE_EXISTING, EvaluationMode.GENERATE_THEN_EVALUATE],
+    format_func=lambda x: "Mode A: Evaluate Existing Outputs" if x == EvaluationMode.EVALUATE_EXISTING 
+                          else "Mode B: Generate Outputs, Then Evaluate",
+    horizontal=True,
+)
+
+st.session_state.evaluation_mode = mode
+
+# File Upload Section
+st.header("2. Upload Evaluation Data")
+
+if mode == EvaluationMode.EVALUATE_EXISTING:
+    st.info("Upload a CSV with columns: `input`, `output`, `expected_output` (and optionally `id`)")
+else:
+    st.info("Upload a CSV with columns: `input`, `expected_output` (and optionally `id`)")
+
+uploaded_file = st.file_uploader(
+    "Choose a CSV file",
+    type="csv",
+    help="Maximum file size: 200MB",
+)
+
+if uploaded_file is not None:
+    try:
+        # Load and validate data
+        df = pd.read_csv(uploaded_file)
+        
+        # Validate columns based on mode
+        required_cols = ["input", "expected_output"]
+        if mode == EvaluationMode.EVALUATE_EXISTING:
+            required_cols.append("output")
+        
+        is_valid, message = validate_csv_columns(df, required_cols)
+        
+        if not is_valid:
+            st.error(f"❌ {message}")
+            st.stop()
+        
+        # Show data preview
+        st.success(f"✅ Loaded {len(df)} rows successfully!")
+        
+        with st.expander("📊 Data Preview (first 5 rows)"):
+            st.dataframe(df.head(), use_container_width=True)
+        
+        # Convert to evaluation items
+        eval_items = load_evaluation_data(df, mode)
+        st.session_state.eval_data = eval_items
+        
+    except Exception as e:
+        st.error(f"Error loading file: {str(e)}")
+        st.stop()
+
+# Mode B: Actor Model Configuration
+if mode == EvaluationMode.GENERATE_THEN_EVALUATE and st.session_state.eval_data:
+    st.header("3. Configure Actor Model")
+    st.markdown("Select the model that will generate outputs for your inputs.")
+    
+    col1, col2 = st.columns([1, 2])
+    
+    with col1:
+        actor_provider = st.selectbox(
+            "Actor Model Provider",
+            ["openai", "anthropic", "google"],
+            key="actor_provider",
+        )
+        
+        # Model selection based on provider
+        model_options = {
+            "openai": ["gpt-4", "gpt-4-turbo-preview", "gpt-3.5-turbo"],
+            "anthropic": ["claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307"],
+            "google": ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro"],
+        }
+        
+        actor_model = st.selectbox(
+            "Actor Model",
+            model_options[actor_provider],
+            key="actor_model",
+        )
+        
+        actor_temperature = st.slider(
+            "Temperature",
+            min_value=0.0,
+            max_value=1.0,
+            value=0.7,
+            step=0.1,
+            key="actor_temp",
+        )
+        
+        actor_max_tokens = st.number_input(
+            "Max Tokens",
+            min_value=100,
+            max_value=4000,
+            value=1000,
+            step=100,
+            key="actor_tokens",
+        )
+    
+    with col2:
+        actor_system_prompt = st.text_area(
+            "Actor System Prompt (optional)",
+            placeholder="Leave empty to use the input as-is, or provide instructions for how the model should respond",
+            height=200,
+            key="actor_prompt",
+        )
+    
+    # Generate outputs button
+    if st.button("🚀 Generate Outputs", type="primary", key="generate_btn"):
+        with st.spinner("Generating outputs... This may take a few minutes."):
+            progress_bar = st.progress(0)
+            status_text = st.empty()
+            
+            # Create actor configuration
+            actor_config = {
+                "provider": actor_provider,
+                "model": actor_model,
+                "temperature": actor_temperature,
+                "max_tokens": actor_max_tokens,
+                "system_prompt": actor_system_prompt or None,
+                "api_key": st.session_state.api_keys.get(actor_provider),
+            }
+            
+            try:
+                # Run generation
+                updated_items = asyncio.run(
+                    generate_outputs(
+                        st.session_state.eval_data,
+                        actor_config,
+                        progress_callback=lambda i, total: (
+                            progress_bar.progress(i / total),
+                            status_text.text(f"Processing {i}/{total} items...")
+                        ),
+                    )
+                )
+                
+                st.session_state.eval_data = updated_items
+                st.success(f"✅ Successfully generated outputs for {len(updated_items)} items!")
+                
+            except Exception as e:
+                st.error(f"Error generating outputs: {str(e)}")
+                st.stop()
+
+# Scorer Selection Section
+if st.session_state.eval_data and (
+    mode == EvaluationMode.EVALUATE_EXISTING or 
+    (mode == EvaluationMode.GENERATE_THEN_EVALUATE and all(item.output for item in st.session_state.eval_data))
+):
+    st.header("4. Select Scoring Methods")
+    
+    available_scorers = get_available_scorers()
+    
+    selected_scorers = st.multiselect(
+        "Choose one or more scoring methods:",
+        options=list(available_scorers.keys()),
+        default=["exact_match"],
+        format_func=lambda x: available_scorers[x]["display_name"],
+        help="Each scorer will evaluate all items in your dataset",
+    )
+    
+    st.session_state.selected_scorers = selected_scorers
+    
+    # Scorer-specific configuration
+    scorer_configs = {}
+    
+    for scorer_name in selected_scorers:
+        scorer_info = available_scorers[scorer_name]
+        
+        with st.expander(f"⚙️ Configure {scorer_info['display_name']}"):
+            st.markdown(scorer_info["description"])
+            
+            if scorer_name == "fuzzy_match":
+                threshold = st.slider(
+                    "Similarity Threshold",
+                    min_value=0.0,
+                    max_value=1.0,
+                    value=0.8,
+                    step=0.05,
+                    help="Minimum similarity score to consider a match",
+                    key=f"{scorer_name}_threshold",
+                )
+                scorer_configs[scorer_name] = {"threshold": threshold}
+                
+            elif scorer_name == "llm_judge":
+                # Use default judge config or allow override
+                use_default = st.checkbox(
+                    "Use default judge configuration",
+                    value=True,
+                    key=f"{scorer_name}_use_default",
+                )
+                
+                if use_default:
+                    scorer_configs[scorer_name] = st.session_state.model_configs["default_judge_config"].copy()
+                    st.json(scorer_configs[scorer_name])
+                else:
+                    # Allow custom configuration
+                    judge_provider = st.selectbox(
+                        "Judge Provider",
+                        ["openai", "anthropic", "google"],
+                        key=f"{scorer_name}_provider",
+                    )
+                    
+                    model_options = {
+                        "openai": ["gpt-4", "gpt-4-turbo-preview", "gpt-3.5-turbo"],
+                        "anthropic": ["claude-3-opus-20240229", "claude-3-sonnet-20240229"],
+                        "google": ["gemini-1.5-pro", "gemini-1.5-flash"],
+                    }
+                    
+                    judge_model = st.selectbox(
+                        "Judge Model",
+                        model_options[judge_provider],
+                        key=f"{scorer_name}_model",
+                    )
+                    
+                    judge_temp = st.slider(
+                        "Temperature",
+                        0.0, 1.0, 0.3, 0.1,
+                        key=f"{scorer_name}_temp",
+                    )
+                    
+                    judge_prompt = st.text_area(
+                        "Judge Prompt",
+                        value=st.session_state.model_configs["default_judge_config"]["system_prompt"],
+                        height=150,
+                        key=f"{scorer_name}_prompt",
+                    )
+                    
+                    scorer_configs[scorer_name] = {
+                        "provider": judge_provider,
+                        "model": judge_model,
+                        "temperature": judge_temp,
+                        "system_prompt": judge_prompt,
+                        "api_key": st.session_state.api_keys.get(judge_provider),
+                    }
+            else:
+                # No configuration needed
+                scorer_configs[scorer_name] = {}
+    
+    # Run Evaluation Button
+    st.header("5. Run Evaluation")
+    
+    col1, col2, col3 = st.columns([2, 1, 1])
+    
+    with col1:
+        if st.button(
+            "🔬 Start Evaluation",
+            type="primary",
+            use_container_width=True,
+            disabled=not selected_scorers,
+        ):
+            with st.spinner("Running evaluation..."):
+                progress_bar = st.progress(0)
+                status_text = st.empty()
+                
+                try:
+                    # Run evaluation
+                    results = asyncio.run(
+                        run_evaluation(
+                            st.session_state.eval_data,
+                            selected_scorers,
+                            scorer_configs,
+                            st.session_state.api_keys,
+                            progress_callback=lambda i, total: (
+                                progress_bar.progress(i / total),
+                                status_text.text(f"Evaluating {i}/{total} items...")
+                            ),
+                        )
+                    )
+                    
+                    st.session_state.eval_results = results
+                    st.success("✅ Evaluation completed successfully!")
+                    
+                    # Show quick summary
+                    st.markdown("### Quick Summary")
+                    summary_cols = st.columns(len(selected_scorers))
+                    
+                    for idx, scorer_name in enumerate(selected_scorers):
+                        with summary_cols[idx]:
+                            scorer_display = available_scorers[scorer_name]["display_name"]
+                            if scorer_name in results.summary_stats:
+                                stats = results.summary_stats[scorer_name]
+                                st.metric(
+                                    scorer_display,
+                                    f"{stats.get('accuracy', 0):.1%}",
+                                    f"{stats.get('passed', 0)}/{stats.get('total', 0)} passed",
+                                )
+                    
+                    st.info("🎯 Navigate to the **Results** page to see detailed evaluation outcomes.")
+                    
+                except Exception as e:
+                    st.error(f"Error during evaluation: {str(e)}")
+    
+    with col2:
+        st.metric("Total Items", len(st.session_state.eval_data))
+    
+    with col3:
+        st.metric("Selected Scorers", len(selected_scorers))
+
+# Navigation hints
+if not st.session_state.eval_data:
+    st.info("👆 Upload a CSV file to begin evaluation setup.")
+elif mode == EvaluationMode.GENERATE_THEN_EVALUATE and not all(item.output for item in st.session_state.eval_data):
+    st.info("👆 Generate outputs before selecting scorers.")
+elif not st.session_state.selected_scorers:
+    st.info("👆 Select at least one scoring method to run evaluation.")

--- a/app/pages/3_results.py
+++ b/app/pages/3_results.py
@@ -1,4 +1,188 @@
+"""
+Page 3: View Evaluation Results
+"""
 import streamlit as st
+import pandas as pd
+import json
+from typing import Dict, Any, List
 
-st.title("Results")
-st.write("No results yet.")
+st.set_page_config(page_title="Evaluation Results", page_icon="📊", layout="wide")
+
+st.title("📊 Evaluation Results")
+st.markdown("Analyze evaluation outcomes and explore detailed scoring information.")
+
+# Check if results are available
+if st.session_state.eval_results is None:
+    st.warning("⚠️ No evaluation results available. Please run an evaluation first.")
+    st.stop()
+
+results = st.session_state.eval_results
+
+# Summary Statistics
+st.header("1. Summary Statistics")
+
+# Create columns for each scorer
+scorer_cols = st.columns(len(results.summary_stats))
+
+for idx, (scorer_name, stats) in enumerate(results.summary_stats.items()):
+    with scorer_cols[idx]:
+        # Format scorer name for display
+        display_name = scorer_name.replace("_", " ").title()
+        
+        st.markdown(f"### {display_name}")
+        
+        # Main metric
+        accuracy = stats.get("accuracy", 0)
+        st.metric(
+            "Accuracy",
+            f"{accuracy:.1%}",
+            delta=None,
+            help="Percentage of items that passed this scorer",
+        )
+        
+        # Additional stats
+        col1, col2 = st.columns(2)
+        with col1:
+            st.metric("Passed", stats.get("passed", 0))
+        with col2:
+            st.metric("Failed", stats.get("failed", 0))
+        
+        # Score distribution for fuzzy match and LLM judge
+        if scorer_name in ["fuzzy_match", "llm_judge"] and "score_distribution" in stats:
+            st.markdown("**Score Distribution**")
+            score_dist = stats["score_distribution"]
+            st.bar_chart(score_dist)
+
+# Detailed Results Table
+st.header("2. Detailed Results")
+
+# Convert results to DataFrame for display
+def results_to_dataframe(results) -> pd.DataFrame:
+    data = []
+    for item in results.items:
+        row = {
+            "ID": item.id or f"Item {results.items.index(item) + 1}",
+            "Input": item.input[:100] + "..." if len(item.input) > 100 else item.input,
+            "Output": item.output[:100] + "..." if len(item.output) > 100 else item.output,
+            "Expected": item.expected_output[:100] + "..." if len(item.expected_output) > 100 else item.expected_output,
+        }
+        
+        # Add scores for each scorer
+        for score in item.scores:
+            row[f"{score.scorer_name}_score"] = score.score
+            row[f"{score.scorer_name}_passed"] = "✅" if score.passed else "❌"
+        
+        data.append(row)
+    
+    return pd.DataFrame(data)
+
+df_results = results_to_dataframe(results)
+
+# Display options
+col1, col2, col3 = st.columns([1, 1, 2])
+
+with col1:
+    show_full_text = st.checkbox("Show full text", value=False)
+
+with col2:
+    filter_failures = st.checkbox("Show failures only", value=False)
+
+with col3:
+    # Filter by scorer failures
+    if filter_failures:
+        scorer_filter = st.multiselect(
+            "Filter by scorer failures:",
+            [s for s in results.summary_stats.keys()],
+            default=[],
+        )
+
+# Apply filters
+display_df = df_results.copy()
+
+if filter_failures and scorer_filter:
+    # Filter to show only items that failed selected scorers
+    mask = pd.Series([False] * len(display_df))
+    for scorer in scorer_filter:
+        mask |= display_df[f"{scorer}_passed"] == "❌"
+    display_df = display_df[mask]
+
+# Show the table
+st.dataframe(
+    display_df,
+    use_container_width=True,
+    hide_index=True,
+    height=400,
+)
+
+# Detailed Item View
+st.header("3. Detailed Item Analysis")
+
+# Select an item to view details
+item_ids = [item.id or f"Item {idx + 1}" for idx, item in enumerate(results.items)]
+selected_item_id = st.selectbox("Select an item to view details:", item_ids)
+
+# Find the selected item
+selected_idx = item_ids.index(selected_item_id)
+selected_item = results.items[selected_idx]
+
+# Display item details
+col1, col2 = st.columns([1, 1])
+
+with col1:
+    st.markdown("### Input")
+    st.text_area("", value=selected_item.input, height=150, disabled=True, key="detail_input")
+    
+    st.markdown("### Expected Output")
+    st.text_area("", value=selected_item.expected_output, height=150, disabled=True, key="detail_expected")
+
+with col2:
+    st.markdown("### Actual Output")
+    st.text_area("", value=selected_item.output, height=150, disabled=True, key="detail_output")
+    
+    st.markdown("### Metadata")
+    if selected_item.metadata:
+        st.json(selected_item.metadata)
+    else:
+        st.text("No metadata available")
+
+# Scorer Results for Selected Item
+st.markdown("### Scoring Details")
+
+for score in selected_item.scores:
+    with st.expander(f"{score.scorer_name.replace('_', ' ').title()} - {'✅ Passed' if score.passed else '❌ Failed'}"):
+        col1, col2 = st.columns([1, 3])
+        
+        with col1:
+            st.metric("Score", f"{score.score:.3f}")
+            st.metric("Passed", "Yes" if score.passed else "No")
+        
+        with col2:
+            if score.reasoning:
+                st.markdown("**Reasoning:**")
+                st.write(score.reasoning)
+            
+            if score.details:
+                st.markdown("**Additional Details:**")
+                if isinstance(score.details, dict):
+                    st.json(score.details)
+                else:
+                    st.write(score.details)
+
+# Export Results Preview
+st.header("4. Results Summary")
+
+st.info("💡 Go to the **Downloads** page to export full results in various formats.")
+
+# Show configuration used
+with st.expander("📋 Evaluation Configuration"):
+    st.json(results.config)
+
+# Show run metadata
+with st.expander("📊 Run Metadata"):
+    metadata = {
+        "Total Items": len(results.items),
+        "Evaluation Mode": results.metadata.get("mode", "Unknown"),
+        "Run Timestamp": results.metadata.get("timestamp", "Unknown"),
+        "Scorers Used": list(results.summary_stats.keys()),
+    }
+    st.json(metadata)

--- a/app/pages/4_downloads.py
+++ b/app/pages/4_downloads.py
@@ -1,4 +1,189 @@
+"""
+Page 4: Download Center
+"""
 import streamlit as st
+import pandas as pd
+import json
+from datetime import datetime
+import io
+from typing import Dict, Any
 
-st.title("Downloads")
-st.write("Nothing to download yet.")
+from core.reporting import (
+    results_to_csv,
+    results_to_json,
+    generate_summary_report,
+)
+
+st.set_page_config(page_title="Download Center", page_icon="⬇️", layout="wide")
+
+st.title("⬇️ Download Center")
+st.markdown("Export evaluation results and related artifacts.")
+
+# Check if results are available
+if st.session_state.eval_results is None:
+    st.warning("⚠️ No evaluation results available. Please run an evaluation first.")
+    st.stop()
+
+results = st.session_state.eval_results
+
+# File naming
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+base_filename = f"eval_results_{timestamp}"
+
+# Download Options
+st.header("1. Evaluation Results")
+
+col1, col2, col3 = st.columns(3)
+
+with col1:
+    st.markdown("### 📄 CSV Format")
+    st.markdown("Flat table format, ideal for Excel or data analysis tools.")
+    
+    csv_data = results_to_csv(results)
+    st.download_button(
+        label="Download Results CSV",
+        data=csv_data,
+        file_name=f"{base_filename}.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
+
+with col2:
+    st.markdown("### 📋 JSON Format")
+    st.markdown("Structured format with full details and metadata.")
+    
+    json_data = results_to_json(results)
+    st.download_button(
+        label="Download Results JSON",
+        data=json_data,
+        file_name=f"{base_filename}.json",
+        mime="application/json",
+        use_container_width=True,
+    )
+
+with col3:
+    st.markdown("### 📊 Summary Report")
+    st.markdown("Human-readable summary with key insights.")
+    
+    summary_report = generate_summary_report(results)
+    st.download_button(
+        label="Download Summary Report",
+        data=summary_report,
+        file_name=f"{base_filename}_summary.md",
+        mime="text/markdown",
+        use_container_width=True,
+    )
+
+# Additional Exports
+st.header("2. Additional Exports")
+
+col1, col2 = st.columns(2)
+
+with col1:
+    st.markdown("### 🔧 Configuration Export")
+    st.markdown("Export the configuration used for this evaluation run.")
+    
+    config_export = {
+        "evaluation_config": results.config,
+        "model_configs": st.session_state.model_configs,
+        "selected_scorers": st.session_state.selected_scorers,
+        "timestamp": timestamp,
+    }
+    
+    st.download_button(
+        label="Download Configuration",
+        data=json.dumps(config_export, indent=2),
+        file_name=f"{base_filename}_config.json",
+        mime="application/json",
+        use_container_width=True,
+    )
+
+with col2:
+    st.markdown("### 📈 Detailed Scores")
+    st.markdown("Export individual scores for each item and scorer.")
+    
+    # Create detailed scores DataFrame
+    scores_data = []
+    for item in results.items:
+        for score in item.scores:
+            scores_data.append({
+                "item_id": item.id or f"Item_{results.items.index(item) + 1}",
+                "scorer": score.scorer_name,
+                "score": score.score,
+                "passed": score.passed,
+                "reasoning": score.reasoning,
+            })
+    
+    scores_df = pd.DataFrame(scores_data)
+    scores_csv = scores_df.to_csv(index=False)
+    
+    st.download_button(
+        label="Download Detailed Scores",
+        data=scores_csv,
+        file_name=f"{base_filename}_detailed_scores.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
+
+# Future Placeholders
+st.header("3. Coming Soon")
+
+col1, col2 = st.columns(2)
+
+with col1:
+    st.markdown("### 📝 Logs")
+    st.markdown("*Detailed execution logs will be available in a future update.*")
+    st.button("Download Logs", disabled=True, use_container_width=True)
+
+with col2:
+    st.markdown("### 🔍 Traces")
+    st.markdown("*OpenTelemetry traces will be available in a future update.*")
+    st.button("Download Traces", disabled=True, use_container_width=True)
+
+# Preview Section
+st.header("4. Export Preview")
+
+preview_type = st.selectbox(
+    "Select export type to preview:",
+    ["CSV Results", "JSON Results", "Summary Report", "Configuration"],
+)
+
+with st.expander("Preview", expanded=True):
+    if preview_type == "CSV Results":
+        # Show first few rows of CSV
+        csv_preview = results_to_csv(results).split('\n')[:10]
+        st.text('\n'.join(csv_preview) + "\n...")
+    
+    elif preview_type == "JSON Results":
+        # Show truncated JSON
+        json_obj = json.loads(results_to_json(results))
+        json_obj["items"] = json_obj["items"][:2]  # Show only first 2 items
+        st.json(json_obj)
+    
+    elif preview_type == "Summary Report":
+        # Show first part of summary
+        summary_lines = generate_summary_report(results).split('\n')[:30]
+        st.markdown('\n'.join(summary_lines) + "\n\n*... (truncated)*")
+    
+    else:  # Configuration
+        st.json(config_export)
+
+# Usage Tips
+st.header("5. Export Tips")
+
+st.info("""
+**💡 Tips for using exported data:**
+
+- **CSV Format**: Best for importing into Excel, Google Sheets, or data analysis tools like pandas
+- **JSON Format**: Ideal for programmatic processing or archiving complete evaluation runs
+- **Summary Report**: Great for sharing results with stakeholders or including in documentation
+- **Configuration Export**: Useful for reproducing evaluation runs or debugging issues
+
+**📊 For advanced analysis**, consider using the JSON export with a Jupyter notebook to create custom visualizations and deeper insights.
+""")
+
+# Footer
+st.markdown("---")
+st.markdown(
+    f"*Results generated on {datetime.now().strftime('%Y-%m-%d at %H:%M:%S')}*"
+)


### PR DESCRIPTION
## Summary
- implement full evaluation setup page with CSV upload, generation options, scoring selection, and evaluation run
- build results viewer showing summary metrics and item detail inspection
- add download center for exporting results, summaries, and config

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843a4dac614832789c8f38d4d2ded12