### PR TITLE
Expand scoring utilities and reporting features

### DIFF
--- a/core/evaluation.py
+++ b/core/evaluation.py
@@ -1,12 +1,26 @@
 """Evaluation orchestration."""
 from typing import Iterable, List
-from .data_models import EvalRecord, Score, RunMetadata, RunResult
-from .scoring import exact_match
+from .data_models import (
+    EvalRecord,
+    Score,
+    RunMetadata,
+    RunResult,
+    EvaluationItem,
+)
+from .scoring import create_scorer
 
 
 def run_evaluation(records: Iterable[EvalRecord]) -> RunResult:
     scores: List[Score] = []
-    for record in records:
-        scores.append(exact_match.score(record, {}))
+    scorer = create_scorer("exact_match")
+    for idx, record in enumerate(records):
+        item = EvaluationItem(
+            id=idx,
+            input=record.prompt,
+            expected_output=record.expected,
+            output=record.output or "",
+        )
+        result = scorer.score(item)
+        scores.append(Score(value=result.score, meta={"passed": result.passed}))
     metadata = RunMetadata(scorer="exact_match")
     return RunResult(records=list(records), scores=scores, metadata=metadata)

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -1,4 +1,159 @@
-"""Logging configuration."""
+"""
+Logging configuration for the application.
+"""
 import logging
+import sys
+from pathlib import Path
+from datetime import datetime
+import os
 
-logging.basicConfig(level=logging.INFO)
+
+def setup_logging(
+    log_level: str = None,
+    log_file: str = None,
+    log_to_console: bool = True,
+) -> None:
+    """
+    Set up logging configuration for the application.
+    
+    Args:
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR)
+        log_file: Optional log file path
+        log_to_console: Whether to log to console
+    """
+    # Get log level from environment or parameter
+    if log_level is None:
+        log_level = os.getenv("LOG_LEVEL", "INFO")
+    
+    # Convert string to logging level
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        numeric_level = logging.INFO
+    
+    # Create logs directory if needed
+    if log_file:
+        log_dir = Path(log_file).parent
+        log_dir.mkdir(exist_ok=True)
+    
+    # Configure logging format
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+    
+    # Configure handlers
+    handlers = []
+    
+    if log_to_console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(logging.Formatter(log_format, date_format))
+        handlers.append(console_handler)
+    
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter(log_format, date_format))
+        handlers.append(file_handler)
+    
+    # Configure root logger
+    logging.basicConfig(
+        level=numeric_level,
+        format=log_format,
+        datefmt=date_format,
+        handlers=handlers,
+        force=True,  # Override any existing configuration
+    )
+    
+    # Configure specific loggers
+    # Reduce noise from HTTP libraries
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("anthropic").setLevel(logging.WARNING)
+    
+    # Log startup message
+    logger = logging.getLogger(__name__)
+    logger.info(f"Logging initialized at {log_level} level")
+    if log_file:
+        logger.info(f"Logging to file: {log_file}")
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Get a logger instance with the given name.
+    
+    Args:
+        name: Logger name (typically __name__)
+    
+    Returns:
+        Logger instance
+    """
+    return logging.getLogger(name)
+
+
+class LogContext:
+    """Context manager for temporary log level changes."""
+    
+    def __init__(self, logger: logging.Logger, level: int):
+        self.logger = logger
+        self.new_level = level
+        self.old_level = logger.level
+    
+    def __enter__(self):
+        self.logger.setLevel(self.new_level)
+        return self.logger
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logger.setLevel(self.old_level)
+
+
+def log_function_call(func):
+    """Decorator to log function calls and results."""
+    import functools
+    
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        logger = logging.getLogger(func.__module__)
+        logger.debug(f"Calling {func.__name__} with args={args}, kwargs={kwargs}")
+        
+        try:
+            result = func(*args, **kwargs)
+            logger.debug(f"{func.__name__} returned: {result}")
+            return result
+        except Exception as e:
+            logger.error(f"{func.__name__} raised exception: {e}")
+            raise
+    
+    return wrapper
+
+
+def create_run_logger(run_id: str) -> logging.Logger:
+    """
+    Create a logger specific to an evaluation run.
+    
+    Args:
+        run_id: Unique identifier for the run
+    
+    Returns:
+        Logger instance for the run
+    """
+    # Create a dedicated logger for this run
+    logger_name = f"eval_run.{run_id}"
+    logger = logging.getLogger(logger_name)
+    
+    # Add a file handler specific to this run
+    log_dir = Path("logs/runs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    
+    log_file = log_dir / f"{run_id}.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(message)s",
+            "%Y-%m-%d %H:%M:%S"
+        )
+    )
+    
+    logger.addHandler(file_handler)
+    logger.setLevel(logging.DEBUG)
+    
+    logger.info(f"Started evaluation run: {run_id}")
+    
+    return logger

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -1,6 +1,285 @@
-"""Reporting helpers."""
-from .data_models import RunResult
+"""
+Reporting utilities for converting evaluation results to various formats.
+"""
+import json
+import pandas as pd
+from typing import Dict, Any, List
+from datetime import datetime
+import io
+
+from core.data_models import EvaluationResults, EvaluationItem
 
 
-def to_dict(result: RunResult) -> dict:
-    return result.dict()
+def results_to_csv(results: EvaluationResults) -> str:
+    """
+    Convert evaluation results to CSV format.
+    
+    Args:
+        results: Evaluation results object
+    
+    Returns:
+        CSV string
+    """
+    data = []
+    
+    for item in results.items:
+        row = {
+            "id": item.id,
+            "input": item.input,
+            "output": item.output,
+            "expected_output": item.expected_output,
+        }
+        
+        # Add metadata columns
+        for key, value in item.metadata.items():
+            row[f"metadata_{key}"] = value
+        
+        # Add scores for each scorer
+        for score in item.scores:
+            scorer_name = score.scorer_name
+            row[f"{scorer_name}_score"] = score.score
+            row[f"{scorer_name}_passed"] = score.passed
+            row[f"{scorer_name}_reasoning"] = score.reasoning
+            if score.error:
+                row[f"{scorer_name}_error"] = score.error
+        
+        data.append(row)
+    
+    # Convert to DataFrame
+    df = pd.DataFrame(data)
+    
+    # Convert to CSV string
+    csv_buffer = io.StringIO()
+    df.to_csv(csv_buffer, index=False)
+    return csv_buffer.getvalue()
+
+
+def results_to_json(results: EvaluationResults) -> str:
+    """
+    Convert evaluation results to JSON format.
+    
+    Args:
+        results: Evaluation results object
+    
+    Returns:
+        JSON string
+    """
+    # Use Pydantic's serialization
+    return results.model_dump_json(indent=2)
+
+
+def generate_summary_report(results: EvaluationResults) -> str:
+    """
+    Generate a human-readable summary report in Markdown format.
+    
+    Args:
+        results: Evaluation results object
+    
+    Returns:
+        Markdown-formatted report string
+    """
+    report_lines = []
+    
+    # Header
+    report_lines.append("# Evaluation Summary Report")
+    report_lines.append("")
+    report_lines.append(f"Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    report_lines.append("")
+    
+    # Overview
+    report_lines.append("## Overview")
+    report_lines.append("")
+    report_lines.append(f"- **Total Items Evaluated**: {len(results.items)}")
+    report_lines.append(f"- **Evaluation Mode**: {results.metadata.get('mode', 'Unknown')}")
+    report_lines.append(f"- **Duration**: {results.metadata.get('duration_seconds', 0):.2f} seconds")
+    report_lines.append(f"- **Scorers Used**: {', '.join(results.summary_stats.keys())}")
+    report_lines.append("")
+    
+    # Summary Statistics
+    report_lines.append("## Summary Statistics")
+    report_lines.append("")
+    
+    for scorer_name, stats in results.summary_stats.items():
+        report_lines.append(f"### {scorer_name.replace('_', ' ').title()}")
+        report_lines.append("")
+        report_lines.append(f"- **Accuracy**: {stats.get('accuracy', 0):.1%}")
+        report_lines.append(f"- **Items Passed**: {stats.get('passed', 0)}/{stats.get('total', 0)}")
+        report_lines.append(f"- **Items Failed**: {stats.get('failed', 0)}/{stats.get('total', 0)}")
+        
+        if stats.get('errors', 0) > 0:
+            report_lines.append(f"- **Errors**: {stats.get('errors', 0)}")
+        
+        report_lines.append(f"- **Average Score**: {stats.get('average_score', 0):.3f}")
+        report_lines.append(f"- **Score Range**: {stats.get('min_score', 0):.3f} - {stats.get('max_score', 0):.3f}")
+        
+        # Score distribution if available
+        if 'score_distribution' in stats:
+            report_lines.append("")
+            report_lines.append("**Score Distribution:**")
+            for range_label, count in stats['score_distribution'].items():
+                report_lines.append(f"  - {range_label}: {count} items")
+        
+        report_lines.append("")
+    
+    # Failure Analysis
+    report_lines.append("## Failure Analysis")
+    report_lines.append("")
+    
+    # Collect failures by scorer
+    failures_by_scorer = {}
+    for item in results.items:
+        for score in item.scores:
+            if not score.passed and not score.error:
+                if score.scorer_name not in failures_by_scorer:
+                    failures_by_scorer[score.scorer_name] = []
+                failures_by_scorer[score.scorer_name].append({
+                    "id": item.id,
+                    "score": score.score,
+                    "reasoning": score.reasoning,
+                })
+    
+    if failures_by_scorer:
+        for scorer_name, failures in failures_by_scorer.items():
+            report_lines.append(f"### {scorer_name.replace('_', ' ').title()} Failures")
+            report_lines.append("")
+            report_lines.append(f"Total failures: {len(failures)}")
+            report_lines.append("")
+            
+            # Show top 5 failures
+            for failure in failures[:5]:
+                report_lines.append(f"- **Item {failure['id']}** (Score: {failure['score']:.3f})")
+                if failure['reasoning']:
+                    report_lines.append(f"  - Reason: {failure['reasoning'][:100]}...")
+            
+            if len(failures) > 5:
+                report_lines.append(f"- ... and {len(failures) - 5} more failures")
+            
+            report_lines.append("")
+    else:
+        report_lines.append("No failures detected across all scorers.")
+        report_lines.append("")
+    
+    # Configuration Used
+    report_lines.append("## Configuration")
+    report_lines.append("")
+    report_lines.append("```json")
+    report_lines.append(json.dumps(results.config, indent=2))
+    report_lines.append("```")
+    report_lines.append("")
+    
+    # Recommendations
+    report_lines.append("## Recommendations")
+    report_lines.append("")
+    
+    # Generate recommendations based on results
+    recommendations = generate_recommendations(results)
+    for rec in recommendations:
+        report_lines.append(f"- {rec}")
+    
+    return "\n".join(report_lines)
+
+
+def generate_recommendations(results: EvaluationResults) -> List[str]:
+    """
+    Generate recommendations based on evaluation results.
+    
+    Args:
+        results: Evaluation results object
+    
+    Returns:
+        List of recommendation strings
+    """
+    recommendations = []
+    
+    # Check overall performance
+    avg_accuracy = sum(
+        stats.get('accuracy', 0) for stats in results.summary_stats.values()
+    ) / len(results.summary_stats) if results.summary_stats else 0
+    
+    if avg_accuracy < 0.5:
+        recommendations.append(
+            "Overall accuracy is below 50%. Consider reviewing the model's training data or prompts."
+        )
+    elif avg_accuracy < 0.8:
+        recommendations.append(
+            "There's room for improvement. Focus on the specific failure cases to identify patterns."
+        )
+    else:
+        recommendations.append(
+            "Good overall performance! Consider adding more challenging test cases."
+        )
+    
+    # Check for scorer-specific issues
+    for scorer_name, stats in results.summary_stats.items():
+        if stats.get('errors', 0) > 0:
+            recommendations.append(
+                f"The {scorer_name} scorer encountered errors. Check API limits or configuration."
+            )
+        
+        if scorer_name == "exact_match" and stats.get('accuracy', 0) < 0.3:
+            recommendations.append(
+                "Low exact match scores. Consider using fuzzy matching for more flexibility."
+            )
+        
+        if scorer_name == "llm_judge" and stats.get('average_score', 0) < 0.5:
+            recommendations.append(
+                "LLM judge scores are low. Review the judge prompt for clarity and criteria."
+            )
+    
+    # Check for consistency across scorers
+    if len(results.summary_stats) > 1:
+        accuracies = [stats.get('accuracy', 0) for stats in results.summary_stats.values()]
+        variance = max(accuracies) - min(accuracies)
+        if variance > 0.3:
+            recommendations.append(
+                "Large variance in scorer results. Ensure all scorers are properly configured and aligned."
+            )
+    
+    return recommendations
+
+
+def export_detailed_analysis(
+    results: EvaluationResults,
+    output_path: str,
+    include_all_items: bool = False,
+) -> None:
+    """
+    Export a detailed analysis to a file.
+    
+    Args:
+        results: Evaluation results object
+        output_path: Path to save the analysis
+        include_all_items: Whether to include all items or just failures
+    """
+    with open(output_path, 'w') as f:
+        # Write summary
+        f.write(generate_summary_report(results))
+        f.write("\n\n")
+        
+        # Write detailed item analysis
+        f.write("# Detailed Item Analysis\n\n")
+        
+        items_to_analyze = results.items
+        if not include_all_items:
+            # Filter to items with at least one failure
+            items_to_analyze = [
+                item for item in results.items
+                if any(not score.passed for score in item.scores)
+            ]
+        
+        for item in items_to_analyze:
+            f.write(f"## Item: {item.id}\n\n")
+            f.write(f"**Input:**\n```\n{item.input}\n```\n\n")
+            f.write(f"**Expected Output:**\n```\n{item.expected_output}\n```\n\n")
+            f.write(f"**Actual Output:**\n```\n{item.output}\n```\n\n")
+
+            f.write("**Scores:**\n")
+            for score in item.scores:
+                status = "✅ PASS" if score.passed else "❌ FAIL"
+                f.write(f"- {score.scorer_name}: {status} (Score: {score.score:.3f})\n")
+                if score.reasoning:
+                    f.write(f"  - Reasoning: {score.reasoning}\n")
+                if score.error:
+                    f.write(f"  - Error: {score.error}\n")
+
+            f.write("\n---\n\n")

--- a/core/scoring/__init__.py
+++ b/core/scoring/__init__.py
@@ -1,9 +1,124 @@
-"""Scoring modules."""
-from importlib import import_module
-from typing import Dict, Callable
+"""
+Scoring module containing various evaluation scorers.
+"""
+from typing import Dict, Any, Type
+from abc import ABC, abstractmethod
 
-__all__ = ["exact_match", "fuzzy_match", "llm_judge", "list_scorers"]
+from core.data_models import EvaluationItem, ScorerResult
 
 
-def list_scorers() -> Dict[str, Callable]:
-    return {name: import_module(f"core.scoring.{name}") for name in ["exact_match", "fuzzy_match", "llm_judge"]}
+class BaseScorer(ABC):
+    """Abstract base class for all scorers."""
+    
+    def __init__(self, config: Dict[str, Any] = None):
+        """
+        Initialize the scorer with configuration.
+        
+        Args:
+            config: Scorer-specific configuration
+        """
+        self.config = config or {}
+    
+    @abstractmethod
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score an evaluation item.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with score and details
+        """
+        pass
+    
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the name of this scorer."""
+        pass
+    
+    @property
+    def description(self) -> str:
+        """Return a description of this scorer."""
+        return f"{self.name} scorer"
+
+
+# Import specific scorers
+from core.scoring.exact_match import ExactMatchScorer
+from core.scoring.fuzzy_match import FuzzyMatchScorer
+from core.scoring.llm_judge import LLMJudgeScorer
+
+
+# Registry of available scorers
+SCORER_REGISTRY: Dict[str, Type[BaseScorer]] = {
+    "exact_match": ExactMatchScorer,
+    "fuzzy_match": FuzzyMatchScorer,
+    "llm_judge": LLMJudgeScorer,
+}
+
+
+def get_available_scorers() -> Dict[str, Dict[str, Any]]:
+    """
+    Get information about all available scorers.
+    
+    Returns:
+        Dictionary mapping scorer names to their information
+    """
+    scorers_info = {}
+    
+    for name, scorer_class in SCORER_REGISTRY.items():
+        scorer = scorer_class()
+        scorers_info[name] = {
+            "class": scorer_class,
+            "display_name": scorer.name,
+            "description": scorer.description,
+        }
+    
+    return scorers_info
+
+
+def create_scorer(name: str, config: Dict[str, Any] = None) -> BaseScorer:
+    """
+    Create a scorer instance by name.
+    
+    Args:
+        name: Name of the scorer
+        config: Configuration for the scorer
+    
+    Returns:
+        Scorer instance
+    
+    Raises:
+        ValueError: If scorer name is not found
+    """
+    if name not in SCORER_REGISTRY:
+        raise ValueError(f"Unknown scorer: {name}. Available: {list(SCORER_REGISTRY.keys())}")
+    
+    scorer_class = SCORER_REGISTRY[name]
+    return scorer_class(config)
+
+
+def register_scorer(name: str, scorer_class: Type[BaseScorer]) -> None:
+    """
+    Register a new scorer class.
+    
+    Args:
+        name: Name to register the scorer under
+        scorer_class: The scorer class
+    """
+    if not issubclass(scorer_class, BaseScorer):
+        raise TypeError("Scorer class must inherit from BaseScorer")
+    
+    SCORER_REGISTRY[name] = scorer_class
+
+
+__all__ = [
+    "BaseScorer",
+    "ExactMatchScorer",
+    "FuzzyMatchScorer",
+    "LLMJudgeScorer",
+    "get_available_scorers",
+    "create_scorer",
+    "register_scorer",
+]

--- a/core/scoring/exact_match.py
+++ b/core/scoring/exact_match.py
@@ -1,7 +1,180 @@
-"""Exact match scorer."""
-from core.data_models import EvalRecord, Score
+"""
+Exact match scorer - checks if output exactly matches expected output.
+"""
+from core.scoring import BaseScorer
+from core.data_models import EvaluationItem, ScorerResult
 
 
-def score(record: EvalRecord, cfg: dict) -> Score:
-    value = 1.0 if record.output == record.expected else 0.0
-    return Score(value=value)
+class ExactMatchScorer(BaseScorer):
+    """
+    Scorer that checks for exact string match between output and expected output.
+    """
+    
+    @property
+    def name(self) -> str:
+        return "Exact Match"
+    
+    @property
+    def description(self) -> str:
+        return "Checks if the output exactly matches the expected output (case-sensitive)"
+    
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score an item based on exact string match.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with binary score (1.0 for match, 0.0 for no match)
+        """
+        if item.output is None:
+            return ScorerResult(
+                scorer_name="exact_match",
+                score=0.0,
+                passed=False,
+                reasoning="No output provided",
+            )
+        
+        # Check for exact match
+        is_match = item.output.strip() == item.expected_output.strip()
+        
+        return ScorerResult(
+            scorer_name="exact_match",
+            score=1.0 if is_match else 0.0,
+            passed=is_match,
+            reasoning="Exact match found" if is_match else "Output does not exactly match expected",
+            details={
+                "output_length": len(item.output),
+                "expected_length": len(item.expected_output),
+                "stripped_match": item.output.strip() == item.expected_output.strip(),
+            }
+        )
+
+
+class CaseInsensitiveExactMatchScorer(BaseScorer):
+    """
+    Scorer that checks for exact match ignoring case.
+    """
+    
+    @property
+    def name(self) -> str:
+        return "Case-Insensitive Exact Match"
+    
+    @property
+    def description(self) -> str:
+        return "Checks if the output matches expected output ignoring case differences"
+    
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score an item based on case-insensitive exact match.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with binary score
+        """
+        if item.output is None:
+            return ScorerResult(
+                scorer_name="case_insensitive_exact_match",
+                score=0.0,
+                passed=False,
+                reasoning="No output provided",
+            )
+        
+        # Check for case-insensitive match
+        is_match = item.output.strip().lower() == item.expected_output.strip().lower()
+        
+        return ScorerResult(
+            scorer_name="case_insensitive_exact_match",
+            score=1.0 if is_match else 0.0,
+            passed=is_match,
+            reasoning="Case-insensitive match found" if is_match else "Output does not match (case-insensitive)",
+            details={
+                "case_sensitive_match": item.output.strip() == item.expected_output.strip(),
+                "case_insensitive_match": is_match,
+            }
+        )
+
+
+class NormalizedExactMatchScorer(BaseScorer):
+    """
+    Scorer that normalizes text before checking for exact match.
+    Normalization includes: lowercasing, removing extra whitespace, punctuation normalization.
+    """
+    
+    @property
+    def name(self) -> str:
+        return "Normalized Exact Match"
+    
+    @property
+    def description(self) -> str:
+        return "Checks for match after normalizing whitespace, case, and punctuation"
+    
+    def normalize_text(self, text: str) -> str:
+        """
+        Normalize text for comparison.
+        
+        Args:
+            text: Text to normalize
+        
+        Returns:
+            Normalized text
+        """
+        import re
+        
+        # Convert to lowercase
+        text = text.lower()
+        
+        # Replace multiple whitespace with single space
+        text = re.sub(r'\s+', ' ', text)
+        
+        # Remove leading/trailing whitespace
+        text = text.strip()
+        
+        # Normalize common punctuation
+        text = text.replace('"', '"').replace('"', '"')  # Smart quotes
+        text = text.replace('\u2019', "'").replace('\u2018', "'")  # Smart apostrophes
+        
+        # Remove trailing punctuation if configured
+        if self.config.get("ignore_trailing_punctuation", False):
+            text = re.sub(r'[.!?;,]+$', '', text)
+        
+        return text
+    
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score an item based on normalized exact match.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with binary score
+        """
+        if item.output is None:
+            return ScorerResult(
+                scorer_name="normalized_exact_match",
+                score=0.0,
+                passed=False,
+                reasoning="No output provided",
+            )
+        
+        # Normalize both texts
+        normalized_output = self.normalize_text(item.output)
+        normalized_expected = self.normalize_text(item.expected_output)
+        
+        is_match = normalized_output == normalized_expected
+        
+        return ScorerResult(
+            scorer_name="normalized_exact_match",
+            score=1.0 if is_match else 0.0,
+            passed=is_match,
+            reasoning="Normalized match found" if is_match else "No match after normalization",
+            details={
+                "raw_match": item.output == item.expected_output,
+                "normalized_output": normalized_output,
+                "normalized_expected": normalized_expected,
+            }
+        )

--- a/core/scoring/fuzzy_match.py
+++ b/core/scoring/fuzzy_match.py
@@ -1,8 +1,158 @@
-"""Fuzzy match scorer."""
-from difflib import SequenceMatcher
-from core.data_models import EvalRecord, Score
+"""
+Fuzzy match scorer - uses string similarity algorithms to score matches.
+"""
+from fuzzywuzzy import fuzz
+from typing import Dict, Any
+
+from core.scoring import BaseScorer
+from core.data_models import EvaluationItem, ScorerResult
 
 
-def score(record: EvalRecord, cfg: dict) -> Score:
-    ratio = SequenceMatcher(None, record.expected, record.output or "").ratio()
-    return Score(value=ratio)
+class FuzzyMatchScorer(BaseScorer):
+    """
+    Scorer that uses fuzzy string matching to calculate similarity.
+    """
+    
+    def __init__(self, config: Dict[str, Any] = None):
+        super().__init__(config)
+        self.threshold = self.config.get("threshold", 0.8)
+        self.algorithm = self.config.get("algorithm", "token_sort_ratio")
+    
+    @property
+    def name(self) -> str:
+        return "Fuzzy Match"
+    
+    @property
+    def description(self) -> str:
+        return f"Uses fuzzy string matching with {self.algorithm} algorithm (threshold: {self.threshold})"
+    
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score an item using fuzzy string matching.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with similarity score (0.0 to 1.0)
+        """
+        if item.output is None:
+            return ScorerResult(
+                scorer_name="fuzzy_match",
+                score=0.0,
+                passed=False,
+                reasoning="No output provided",
+            )
+        
+        # Get the appropriate fuzzy matching function
+        if self.algorithm == "ratio":
+            similarity = fuzz.ratio(item.output, item.expected_output)
+        elif self.algorithm == "partial_ratio":
+            similarity = fuzz.partial_ratio(item.output, item.expected_output)
+        elif self.algorithm == "token_sort_ratio":
+            similarity = fuzz.token_sort_ratio(item.output, item.expected_output)
+        elif self.algorithm == "token_set_ratio":
+            similarity = fuzz.token_set_ratio(item.output, item.expected_output)
+        else:
+            # Default to token_sort_ratio
+            similarity = fuzz.token_sort_ratio(item.output, item.expected_output)
+        
+        # Convert to 0-1 scale
+        score = similarity / 100.0
+        passed = score >= self.threshold
+        
+        # Generate reasoning
+        if passed:
+            reasoning = f"Similarity score {score:.2f} meets threshold {self.threshold}"
+        else:
+            reasoning = f"Similarity score {score:.2f} below threshold {self.threshold}"
+        
+        return ScorerResult(
+            scorer_name="fuzzy_match",
+            score=score,
+            passed=passed,
+            reasoning=reasoning,
+            details={
+                "algorithm": self.algorithm,
+                "threshold": self.threshold,
+                "raw_similarity": similarity,
+                "all_scores": {
+                    "ratio": fuzz.ratio(item.output, item.expected_output),
+                    "partial_ratio": fuzz.partial_ratio(item.output, item.expected_output),
+                    "token_sort_ratio": fuzz.token_sort_ratio(item.output, item.expected_output),
+                    "token_set_ratio": fuzz.token_set_ratio(item.output, item.expected_output),
+                }
+            }
+        )
+
+
+class LevenshteinScorer(BaseScorer):
+    """
+    Scorer that uses Levenshtein distance for similarity calculation.
+    """
+    
+    def __init__(self, config: Dict[str, Any] = None):
+        super().__init__(config)
+        self.threshold = self.config.get("threshold", 0.8)
+        self.normalize = self.config.get("normalize", True)
+    
+    @property
+    def name(self) -> str:
+        return "Levenshtein Distance"
+    
+    @property
+    def description(self) -> str:
+        return f"Uses Levenshtein distance to measure similarity (threshold: {self.threshold})"
+    
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """
+        Score using Levenshtein distance.
+        
+        Args:
+            item: The evaluation item to score
+        
+        Returns:
+            ScorerResult with similarity score
+        """
+        if item.output is None:
+            return ScorerResult(
+                scorer_name="levenshtein",
+                score=0.0,
+                passed=False,
+                reasoning="No output provided",
+            )
+        
+        import Levenshtein
+        
+        output = item.output
+        expected = item.expected_output
+        
+        # Optionally normalize
+        if self.normalize:
+            output = output.lower().strip()
+            expected = expected.lower().strip()
+        
+        # Calculate distance and ratio
+        distance = Levenshtein.distance(output, expected)
+        max_len = max(len(output), len(expected))
+        
+        # Convert to similarity score (0-1)
+        if max_len == 0:
+            score = 1.0
+        else:
+            score = 1.0 - (distance / max_len)
+        
+        passed = score >= self.threshold
+        
+        return ScorerResult(
+            scorer_name="levenshtein",
+            score=score,
+            passed=passed,
+            reasoning=f"Edit distance: {distance}, similarity: {score:.2f}",
+            details={
+                "edit_distance": distance,
+                "max_length": max_len,
+                "threshold": self.threshold,
+                "normalized": self.normalize,
+            }
+        )

--- a/core/scoring/llm_judge.py
+++ b/core/scoring/llm_judge.py
@@ -1,7 +1,24 @@
 """LLM-based scorer placeholder."""
-from core.data_models import EvalRecord, Score
+from core.scoring import BaseScorer
+from core.data_models import EvaluationItem, ScorerResult
 
 
-def score(record: EvalRecord, cfg: dict) -> Score:
-    # TODO: integrate with real LLM
-    return Score(value=0.0)
+class LLMJudgeScorer(BaseScorer):
+    """Placeholder scorer that would use an LLM to judge outputs."""
+
+    @property
+    def name(self) -> str:
+        return "LLM Judge"
+
+    @property
+    def description(self) -> str:
+        return "Scores using an LLM as a judge (not implemented)"
+
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """Return a dummy score as the implementation placeholder."""
+        return ScorerResult(
+            scorer_name="llm_judge",
+            score=0.0,
+            passed=False,
+            reasoning="LLM judge not implemented",
+        )

--- a/tests/unit/test_exact_match.py
+++ b/tests/unit/test_exact_match.py
@@ -3,11 +3,13 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from core.data_models import EvalRecord
-from core.scoring import exact_match
+from core.data_models import EvaluationItem
+from core.scoring import ExactMatchScorer
 
 
 def test_exact_match_scores_correctly():
-    rec = EvalRecord(prompt="", expected="hello", output="hello")
-    score = exact_match.score(rec, {})
-    assert score.value == 1.0
+    item = EvaluationItem(id=1, input="", expected_output="hello", output="hello")
+    scorer = ExactMatchScorer()
+    result = scorer.score(item)
+    assert result.score == 1.0
+    assert result.passed


### PR DESCRIPTION
## Summary
- implement new datamodels for evaluation items and results
- overhaul logging configuration
- add full reporting utilities with CSV/JSON export and Markdown summaries
- refactor scoring modules to use classes
- update evaluation orchestration and unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fuzzywuzzy')*

------
https://chatgpt.com/codex/tasks/task_e_6843a6712d788327ac018f351b9ced47