### PR TITLE
Fix Python requirement and smart quote handling

### DIFF
--- a/core/scoring/exact_match.py
+++ b/core/scoring/exact_match.py
@@ -134,8 +134,13 @@ class NormalizedExactMatchScorer(BaseScorer):
         text = text.strip()
         
         # Normalize common punctuation
-        text = text.replace('"', '"').replace('"', '"')  # Smart quotes
-        text = text.replace('\u2019', "'").replace('\u2018', "'")  # Smart apostrophes
+        # Replace smart quotes/apostrophes with straight ones
+        text = (
+            text.replace('\u201c', '"')
+            .replace('\u201d', '"')
+            .replace('\u2019', "'")
+            .replace('\u2018', "'")
+        )
         
         # Remove trailing punctuation if configured
         if self.config.get("ignore_trailing_punctuation", False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ai-eval-workbench"
 version = "0.1.0"
 description = "A modular platform for evaluating AI models and applications"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 authors = [
     {name = "Your Name", email = "your.email@example.com"},
@@ -25,6 +25,7 @@ dependencies = [
     "aiofiles>=23.0.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]
@@ -38,14 +39,14 @@ dev = [
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tests/unit/test_exact_match.py
+++ b/tests/unit/test_exact_match.py
@@ -157,7 +157,7 @@ class TestNormalizedExactMatchScorer:
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
             input="Test",
-            output=""Hello World"",  # Smart quotes
+            output="\u201cHello World\u201d",  # Smart quotes
             expected_output='"Hello World"'    # Regular quotes
         )
         
@@ -171,7 +171,7 @@ class TestNormalizedExactMatchScorer:
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
             input="Test",
-            output="It's working",     # Smart apostrophe
+            output="It\u2019s working",     # Smart apostrophe
             expected_output="It's working"  # Regular apostrophe
         )
         


### PR DESCRIPTION
## Summary
- update `requires-python` to >=3.9 and adjust tooling versions
- include `numpy` in project dependencies
- normalize smart quotes correctly in `NormalizedExactMatchScorer`
- correct smart quote tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6843c00e1d108327bc8513bb291b9ed7