### PR TITLE
Fix scoring imports and add async support

### DIFF
--- a/app/pages/2_eval_setup.py
+++ b/app/pages/2_eval_setup.py
@@ -5,7 +5,10 @@ import streamlit as st
 import pandas as pd
 from typing import List, Dict, Any
 import asyncio
+import nest_asyncio
 from io import StringIO
+
+nest_asyncio.apply()
 
 from core.ingestion import load_evaluation_data, validate_csv_columns
 from core.generation import generate_outputs

--- a/core/data_models.py
+++ b/core/data_models.py
@@ -8,20 +8,6 @@ from datetime import datetime
 from enum import Enum
 
 
-class EvalRecord(BaseModel):
-    """Backward-compatible record for tests."""
-
-    prompt: str
-    expected: str
-    output: Optional[str] = None
-
-
-class Score(BaseModel):
-    """Simple score wrapper used in legacy scorers."""
-
-    value: float = Field(..., ge=0.0, le=1.0)
-
-
 class EvaluationMode(str, Enum):
     """Evaluation modes supported by the system."""
     EVALUATE_EXISTING = "evaluate_existing"

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -103,6 +103,9 @@ def generate_summary_report(results: EvaluationResults) -> str:
     Returns:
         Markdown-formatted report string
     """
+    if not results.items:
+        return "# Evaluation Summary Report\n\nNo evaluation results to summarize."
+
     report_lines = []
     
     # Header
@@ -276,6 +279,9 @@ def export_detailed_analysis(
         output_path: Path to save the analysis
         include_all_items: Whether to include all items or just failures
     """
+    if not results.items:
+        raise ValueError("No evaluation items to export.")
+
     with open(output_path, 'w') as f:
         # Write summary
         f.write(generate_summary_report(results))

--- a/core/scoring/__init__.py
+++ b/core/scoring/__init__.py
@@ -1,47 +1,8 @@
-"""
-Scoring module containing various evaluation scorers.
-"""
-from typing import Dict, Any, Type, Optional
-from abc import ABC, abstractmethod
+"""Scoring module containing various evaluation scorers."""
 
-from core.data_models import EvaluationItem, ScorerResult
+from typing import Dict, Any, Type
 
-
-class BaseScorer(ABC):
-    """Abstract base class for all scorers."""
-    
-    def __init__(self, config: Dict[str, Any] = None):
-        """
-        Initialize the scorer with configuration.
-        
-        Args:
-            config: Scorer-specific configuration
-        """
-        self.config = config or {}
-    
-    @abstractmethod
-    def score(self, item: EvaluationItem) -> ScorerResult:
-        """
-        Score an evaluation item.
-        
-        Args:
-            item: The evaluation item to score
-        
-        Returns:
-            ScorerResult with score and details
-        """
-        pass
-    
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Return the name of this scorer."""
-        pass
-    
-    @property
-    def description(self) -> str:
-        """Return a description of this scorer."""
-        return f"{self.name} scorer"
+from core.scoring.base import BaseScorer
 
 
 # Import specific scorers - do this after BaseScorer is defined

--- a/core/scoring/base.py
+++ b/core/scoring/base.py
@@ -1,0 +1,27 @@
+"""Base scorer class definition."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+from core.data_models import EvaluationItem, ScorerResult
+
+
+class BaseScorer(ABC):
+    """Abstract base class for all scorers."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+
+    @abstractmethod
+    def score(self, item: EvaluationItem) -> ScorerResult:
+        """Score an evaluation item and return the result."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human friendly name for the scorer."""
+
+    @property
+    def description(self) -> str:
+        return f"{self.name} scorer"
+

--- a/core/scoring/exact_match.py
+++ b/core/scoring/exact_match.py
@@ -1,7 +1,7 @@
 """
 Exact match scorer - checks if output exactly matches expected output.
 """
-from core.scoring import BaseScorer
+from core.scoring.base import BaseScorer
 from core.data_models import EvaluationItem, ScorerResult
 
 

--- a/core/scoring/fuzzy_match.py
+++ b/core/scoring/fuzzy_match.py
@@ -4,7 +4,7 @@ Fuzzy match scorer - uses string similarity algorithms to score matches.
 from fuzzywuzzy import fuzz
 from typing import Dict, Any
 
-from core.scoring import BaseScorer
+from core.scoring.base import BaseScorer
 from core.data_models import EvaluationItem, ScorerResult
 
 

--- a/core/scoring/llm_judge.py
+++ b/core/scoring/llm_judge.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from typing import Dict, Any, Optional
 
-from core.scoring import BaseScorer
+from core.scoring.base import BaseScorer
 from core.data_models import EvaluationItem, ScorerResult
 from services.llm_clients import create_llm_client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ aiofiles>=23.0.0
 pytest>=7.0.0
 pytest-asyncio>=0.21.0
 numpy>=1.24.0
+nest-asyncio>=1.5

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,7 +16,7 @@ setup_logging()
 # Page configuration
 st.set_page_config(
     page_title="AI Evaluation Workbench",
-    page_icon="\U0001F52C",
+    page_icon="🔬",
     layout="wide",
     initial_sidebar_state="expanded",
 )
@@ -32,7 +32,7 @@ if "initialized" not in st.session_state:
     st.session_state.run_metadata = {}
 
 # Main page content
-st.title("\U0001F52C AI Evaluation Workbench")
+st.title("🔬 AI Evaluation Workbench")
 st.markdown("---")
 
 col1, col2 = st.columns([2, 1])


### PR DESCRIPTION
## Summary
- fix Unicode escapes in `streamlit_app.py`
- add `BaseScorer` in new module and update imports
- use `nest_asyncio` to allow async calls in Streamlit
- guard reporting helpers against empty datasets
- drop obsolete classes from `data_models`
- add `nest-asyncio` to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6843c18d7d1483279f73cdceab0705dd