### PR TITLE
Fix streamlit sidebar navigation

### DIFF
--- a/app/pages/1_config.py
+++ b/app/pages/1_config.py
@@ -9,8 +9,6 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-st.set_page_config(page_title="System Configuration", page_icon="\u2699\uFE0F", layout="wide")
-
 st.title("\u2699\uFE0F System & Model Configuration")
 st.markdown("Configure API keys and default model parameters for evaluations.")
 

--- a/app/pages/2_eval_setup.py
+++ b/app/pages/2_eval_setup.py
@@ -17,8 +17,6 @@ from core.data_models import EvaluationItem, EvaluationMode
 from core.scoring import get_available_scorers
 from services.llm_clients import create_llm_client
 
-st.set_page_config(page_title="Evaluation Setup", page_icon="📄", layout="wide")
-
 st.title("📄 Evaluation Setup")
 st.markdown("Upload data, configure evaluation mode, and select scoring methods.")
 

--- a/app/pages/3_results.py
+++ b/app/pages/3_results.py
@@ -6,8 +6,6 @@ import pandas as pd
 import json
 from typing import Dict, Any, List
 
-st.set_page_config(page_title="Evaluation Results", page_icon="📊", layout="wide")
-
 st.title("📊 Evaluation Results")
 st.markdown("Analyze evaluation outcomes and explore detailed scoring information.")
 

--- a/app/pages/4_downloads.py
+++ b/app/pages/4_downloads.py
@@ -14,8 +14,6 @@ from core.reporting import (
     generate_summary_report,
 )
 
-st.set_page_config(page_title="Download Center", page_icon="⬇️", layout="wide")
-
 st.title("⬇️ Download Center")
 st.markdown("Export evaluation results and related artifacts.")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,4 @@
-"""
-AI Evaluation Workbench - Main Application Entry Point
-"""
+"""AI Evaluation Workbench - Main Application Entry Point"""
 import streamlit as st
 from pathlib import Path
 import sys
@@ -21,6 +19,47 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
+# Define pages using st.Page
+home_page = st.Page(
+    "streamlit_app_home.py",
+    title="Home",
+    icon="🏠",
+    default=True,
+)
+
+config_page = st.Page(
+    "app/pages/1_config.py",
+    title="System Configuration",
+    icon="⚙️",
+)
+
+eval_setup_page = st.Page(
+    "app/pages/2_eval_setup.py",
+    title="Evaluation Setup",
+    icon="📄",
+)
+
+results_page = st.Page(
+    "app/pages/3_results.py",
+    title="View Results",
+    icon="📊",
+)
+
+downloads_page = st.Page(
+    "app/pages/4_downloads.py",
+    title="Download Center",
+    icon="⬇️",
+)
+
+# Create navigation
+pg = st.navigation([
+    home_page,
+    config_page,
+    eval_setup_page,
+    results_page,
+    downloads_page,
+])
+
 # Initialize session state
 if "initialized" not in st.session_state:
     st.session_state.initialized = True
@@ -31,85 +70,5 @@ if "initialized" not in st.session_state:
     st.session_state.selected_scorers = []
     st.session_state.run_metadata = {}
 
-# Main page content
-st.title("🔬 AI Evaluation Workbench")
-st.markdown("---")
-
-col1, col2 = st.columns([2, 1])
-
-with col1:
-    st.markdown("""
-    Welcome to the AI Evaluation Workbench, a modular platform for evaluating 
-    Large Language Models (LLMs) and AI applications.
-    
-    ### Getting Started
-    
-    1. **Configure System** - Set up your API keys and default model parameters
-    2. **Setup Evaluation** - Upload data and select scoring methods
-    3. **View Results** - Analyze evaluation outcomes
-    4. **Download Results** - Export data for further analysis
-    
-    ### Evaluation Modes
-    
-    - **Mode A**: Evaluate pre-existing model outputs against expected outputs
-    - **Mode B**: Generate outputs from a model, then evaluate them
-    
-    Use the sidebar to navigate between pages.
-    """)
-
-with col2:
-    st.info("""
-    **Quick Tips:**
-    - Start with the System Configuration page
-    - Prepare your CSV data in the required format
-    - Multiple scorers can be applied simultaneously
-    - Results are preserved during your session
-    """)
-
-# Status dashboard
-st.markdown("### Current Status")
-status_cols = st.columns(4)
-
-with status_cols[0]:
-    api_configured = len(st.session_state.api_keys) > 0
-    st.metric(
-        "API Configuration",
-        "\u2705 Configured" if api_configured else "\u274C Not Set",
-        delta=None,
-    )
-
-with status_cols[1]:
-    data_loaded = st.session_state.eval_data is not None
-    st.metric(
-        "Data Loaded",
-        "\u2705 Ready" if data_loaded else "\u274C No Data",
-        delta=None,
-    )
-
-with status_cols[2]:
-    scorers_selected = len(st.session_state.selected_scorers) > 0
-    st.metric(
-        "Scorers Selected",
-        f"\u2705 {len(st.session_state.selected_scorers)}" if scorers_selected else "\u274C None",
-        delta=None,
-    )
-
-with status_cols[3]:
-    results_available = st.session_state.eval_results is not None
-    st.metric(
-        "Results",
-        "\u2705 Available" if results_available else "\u274C Not Run",
-        delta=None,
-    )
-
-# Footer
-st.markdown("---")
-st.markdown(
-    """
-    <div style='text-align: center; color: gray;'>
-        AI Evaluation Workbench v0.1.0 | 
-        <a href='https://github.com/yourusername/ai-eval-workbench'>GitHub</a>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
+# Run the selected page
+pg.run()

--- a/streamlit_app_home.py
+++ b/streamlit_app_home.py
@@ -1,0 +1,90 @@
+"""
+Home page content for AI Evaluation Workbench
+"""
+import streamlit as st
+
+st.title("🔬 AI Evaluation Workbench")
+st.markdown("---")
+
+col1, col2 = st.columns([2, 1])
+
+with col1:
+    st.markdown(
+        """
+    Welcome to the AI Evaluation Workbench, a modular platform for evaluating 
+    Large Language Models (LLMs) and AI applications.
+    
+    ### Getting Started
+    
+    1. **Configure System** - Set up your API keys and default model parameters
+    2. **Setup Evaluation** - Upload data and select scoring methods
+    3. **View Results** - Analyze evaluation outcomes
+    4. **Download Results** - Export data for further analysis
+    
+    ### Evaluation Modes
+    
+    - **Mode A**: Evaluate pre-existing model outputs against expected outputs
+    - **Mode B**: Generate outputs from a model, then evaluate them
+    
+    Use the sidebar to navigate between pages.
+    """
+    )
+
+with col2:
+    st.info(
+        """
+    **Quick Tips:**
+    - Start with the System Configuration page
+    - Prepare your CSV data in the required format
+    - Multiple scorers can be applied simultaneously
+    - Results are preserved during your session
+    """
+    )
+
+# Status dashboard
+st.markdown("### Current Status")
+status_cols = st.columns(4)
+
+with status_cols[0]:
+    api_configured = len(st.session_state.api_keys) > 0
+    st.metric(
+        "API Configuration",
+        "✅ Configured" if api_configured else "❌ Not Set",
+        delta=None,
+    )
+
+with status_cols[1]:
+    data_loaded = st.session_state.eval_data is not None
+    st.metric(
+        "Data Loaded",
+        "✅ Ready" if data_loaded else "❌ No Data",
+        delta=None,
+    )
+
+with status_cols[2]:
+    scorers_selected = len(st.session_state.selected_scorers) > 0
+    st.metric(
+        "Scorers Selected",
+        f"✅ {len(st.session_state.selected_scorers)}" if scorers_selected else "❌ None",
+        delta=None,
+    )
+
+with status_cols[3]:
+    results_available = st.session_state.eval_results is not None
+    st.metric(
+        "Results",
+        "✅ Available" if results_available else "❌ Not Run",
+        delta=None,
+    )
+
+# Footer
+st.markdown("---")
+st.markdown(
+    """
+    <div style='text-align: center; color: gray;'>
+        AI Evaluation Workbench v0.1.0 | 
+        <a href='https://github.com/yourusername/ai-eval-workbench'>GitHub</a>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)


### PR DESCRIPTION
## Summary
- add navigation based on `st.Page`/`st.navigation`
- provide a separate home page module
- remove duplicate `st.set_page_config` calls from page modules

## Testing
- `pytest -q` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843ca7653388327b90782ab369b31cf