### PR TITLE
Add file size validation to upload

### DIFF
--- a/app/pages/2_eval_setup.py
+++ b/app/pages/2_eval_setup.py
@@ -52,6 +52,10 @@ uploaded_file = st.file_uploader(
 )
 
 if uploaded_file is not None:
+    MAX_FILE_SIZE_MB = 100
+    if uploaded_file.size > MAX_FILE_SIZE_MB * 1024 * 1024:
+        st.error(f"❌ File is too large ({uploaded_file.size / 1024**2:.1f}MB). Maximum size is {MAX_FILE_SIZE_MB}MB.")
+        st.stop()
     try:
         # Load and validate data
         df = pd.read_csv(uploaded_file)


### PR DESCRIPTION
## Summary
- validate uploaded CSV size and stop if larger than 100MB

## Testing
- `PYTHONPATH=. pytest -v -m "not requires_api"` *(fails: test_generate_summary_report, test_exact_match_parametrized[--True], test_exact_match_parametrized[  --True])*

------
https://chatgpt.com/codex/tasks/task_e_684521618c708327ab359dfee16c28e6