### PR TITLE
Fix summary report test

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,6 +1,7 @@
 """
 Integration tests for end-to-end evaluation flow.
 """
+
 import pytest
 import asyncio
 import pandas as pd
@@ -19,68 +20,69 @@ from services.llm_clients import create_llm_client
 
 class TestEndToEndEvaluation:
     """Test complete evaluation workflows."""
-    
+
     @pytest.fixture
     def sample_data_file(self):
         """Create a temporary CSV file with sample data."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df = create_sample_data(num_items=5, include_output=True)
             df.to_csv(f.name, index=False)
             yield f.name
         Path(f.name).unlink()
-    
+
     @pytest.fixture
     def sample_items(self):
         """Create sample evaluation items."""
         return [
             EvaluationItem(
-                id="1",
-                input="What is 2+2?",
-                output="4",
-                expected_output="4"
+                id="1", input="What is 2+2?", output="4", expected_output="4"
             ),
             EvaluationItem(
                 id="2",
                 input="What is the capital of France?",
                 output="Paris",
-                expected_output="Paris"
+                expected_output="Paris",
             ),
             EvaluationItem(
                 id="3",
                 input="Translate 'hello' to Spanish",
                 output="Hola",
-                expected_output="hola"  # Different case
+                expected_output="hola",  # Different case
             ),
         ]
-    
+
     def test_load_evaluation_data_from_csv(self, sample_data_file):
         """Test loading evaluation data from CSV file."""
         items = load_evaluation_data(sample_data_file, EvaluationMode.EVALUATE_EXISTING)
-        
+
         assert len(items) == 5
         assert all(isinstance(item, EvaluationItem) for item in items)
-        assert all(item.input and item.output and item.expected_output for item in items)
-    
+        assert all(
+            item.input and item.output and item.expected_output for item in items
+        )
+
     def test_load_evaluation_data_from_dataframe(self):
         """Test loading evaluation data from DataFrame."""
-        df = pd.DataFrame({
-            "input": ["Question 1", "Question 2"],
-            "output": ["Answer 1", "Answer 2"],
-            "expected_output": ["Answer 1", "Answer 2"],
-            "metadata_source": ["test", "test"],
-        })
-        
+        df = pd.DataFrame(
+            {
+                "input": ["Question 1", "Question 2"],
+                "output": ["Answer 1", "Answer 2"],
+                "expected_output": ["Answer 1", "Answer 2"],
+                "metadata_source": ["test", "test"],
+            }
+        )
+
         items = load_evaluation_data(df, EvaluationMode.EVALUATE_EXISTING)
-        
+
         assert len(items) == 2
         assert items[0].metadata["metadata_source"] == "test"
-    
+
     @pytest.mark.asyncio
     async def test_run_evaluation_single_scorer(self, sample_items):
         """Test running evaluation with a single scorer."""
         # Mock API keys
         api_keys = {"openai": "test-key"}
-        
+
         # Run evaluation
         results = await run_evaluation(
             items=sample_items,
@@ -88,18 +90,18 @@ class TestEndToEndEvaluation:
             scorer_configs={},
             api_keys=api_keys,
         )
-        
+
         assert isinstance(results, EvaluationResults)
         assert len(results.items) == 3
         assert all(len(item.scores) == 1 for item in results.items)
         assert "exact_match" in results.summary_stats
-        
+
         # Check summary stats
         stats = results.summary_stats["exact_match"]
         assert stats["total"] == 3
         assert stats["passed"] == 2  # First two should pass
         assert stats["failed"] == 1  # Third fails due to case
-    
+
     @pytest.mark.asyncio
     async def test_run_evaluation_multiple_scorers(self, sample_items):
         """Test running evaluation with multiple scorers."""
@@ -107,23 +109,23 @@ class TestEndToEndEvaluation:
         scorer_configs = {
             "fuzzy_match": {"threshold": 0.8},
         }
-        
+
         results = await run_evaluation(
             items=sample_items,
             selected_scorers=["exact_match", "fuzzy_match"],
             scorer_configs=scorer_configs,
             api_keys={},
         )
-        
+
         assert len(results.items) == 3
         assert all(len(item.scores) == 2 for item in results.items)
         assert "exact_match" in results.summary_stats
         assert "fuzzy_match" in results.summary_stats
-        
+
         # Fuzzy match should pass all items
         fuzzy_stats = results.summary_stats["fuzzy_match"]
         assert fuzzy_stats["passed"] == 3
-    
+
     def test_results_to_csv(self, sample_items):
         """Test converting results to CSV format."""
         # Create mock results
@@ -132,25 +134,30 @@ class TestEndToEndEvaluation:
             config={"test": True},
             metadata={"mode": "test"},
         )
-        
+
         # Add some scores
         from core.data_models import ScorerResult
+
         for item in results.items:
             item.scores.append(
                 ScorerResult(
                     scorer_name="exact_match",
-                    score=1.0 if item.output.lower() == item.expected_output.lower() else 0.0,
+                    score=(
+                        1.0
+                        if item.output.lower() == item.expected_output.lower()
+                        else 0.0
+                    ),
                     passed=item.output.lower() == item.expected_output.lower(),
                     reasoning="Test",
                 )
             )
-        
+
         csv_content = results_to_csv(results)
-        
+
         assert "id,input,output,expected_output" in csv_content
         assert "exact_match_score" in csv_content
         assert "exact_match_passed" in csv_content
-    
+
     def test_results_to_json(self, sample_items):
         """Test converting results to JSON format."""
         results = EvaluationResults(
@@ -158,15 +165,15 @@ class TestEndToEndEvaluation:
             config={"test": True},
             metadata={"mode": "test"},
         )
-        
+
         json_content = results_to_json(results)
         parsed = json.loads(json_content)
-        
+
         assert "items" in parsed
         assert len(parsed["items"]) == 3
         assert "config" in parsed
         assert "metadata" in parsed
-    
+
     def test_generate_summary_report(self, sample_items):
         """Test generating a summary report."""
         # Create results with stats
@@ -175,9 +182,10 @@ class TestEndToEndEvaluation:
             config={"scorers": ["exact_match"]},
             metadata={"mode": "evaluate_existing", "duration_seconds": 1.5},
         )
-        
+
         # Add scores
         from core.data_models import ScorerResult
+
         for i, item in enumerate(results.items):
             item.scores.append(
                 ScorerResult(
@@ -187,24 +195,24 @@ class TestEndToEndEvaluation:
                     reasoning="Match" if i < 2 else "No match",
                 )
             )
-        
+
         # Calculate stats
         results.calculate_summary_stats()
-        
+
         report = generate_summary_report(results)
-        
+
         assert "# Evaluation Summary Report" in report
-        assert "Total Items Evaluated: 3" in report
+        assert "- **Total Items Evaluated**: 3" in report
         assert "Exact Match" in report
-        assert "Accuracy: 66.7%" in report
-        assert "Items Passed: 2/3" in report
-    
+        assert "- **Accuracy**: 66.7%" in report
+        assert "- **Items Passed**: 2/3" in report
+
     @pytest.mark.asyncio
     async def test_complete_workflow_mode_a(self, sample_data_file):
         """Test complete workflow for Mode A (evaluate existing)."""
         # Load data
         items = load_evaluation_data(sample_data_file, EvaluationMode.EVALUATE_EXISTING)
-        
+
         # Run evaluation
         results = await run_evaluation(
             items=items,
@@ -212,12 +220,12 @@ class TestEndToEndEvaluation:
             scorer_configs={"fuzzy_match": {"threshold": 0.9}},
             api_keys={},
         )
-        
+
         # Generate reports
         csv_report = results_to_csv(results)
         json_report = results_to_json(results)
         summary = generate_summary_report(results)
-        
+
         # Verify outputs
         assert len(results.items) == 5
         assert all(len(item.scores) == 2 for item in results.items)
@@ -226,15 +234,15 @@ class TestEndToEndEvaluation:
         assert len(csv_report) > 0
         assert len(json_report) > 0
         assert "# Evaluation Summary Report" in summary
-    
+
     def test_get_available_scorers(self):
         """Test getting list of available scorers."""
         scorers = get_available_scorers()
-        
+
         assert "exact_match" in scorers
         assert "fuzzy_match" in scorers
         assert "llm_judge" in scorers
-        
+
         for scorer_info in scorers.values():
             assert "class" in scorer_info
             assert "display_name" in scorer_info
@@ -246,18 +254,12 @@ class TestEndToEndEvaluation:
     async def test_generate_outputs(self):
         """Test generating outputs using an Actor LLM."""
         items = [
+            EvaluationItem(id="1", input="What is 2+2?", expected_output="4"),
             EvaluationItem(
-                id="1",
-                input="What is 2+2?",
-                expected_output="4"
-            ),
-            EvaluationItem(
-                id="2",
-                input="What is the capital of France?",
-                expected_output="Paris"
+                id="2", input="What is the capital of France?", expected_output="Paris"
             ),
         ]
-        
+
         actor_config = {
             "provider": "openai",
             "model": "gpt-3.5-turbo",
@@ -265,10 +267,10 @@ class TestEndToEndEvaluation:
             "max_tokens": 100,
             "api_key": os.getenv("OPENAI_API_KEY"),  # This would need a real key
         }
-        
+
         # This test would actually call the OpenAI API
         updated_items = await generate_outputs(items, actor_config)
-        
+
         assert len(updated_items) == 2
         assert all(item.output is not None for item in updated_items)
         assert all(len(item.output) > 0 for item in updated_items)
@@ -278,24 +280,24 @@ class TestEndToEndEvaluation:
     async def test_llm_judge_scorer(self):
         """Test LLM Judge scorer with real API calls."""
         from core.scoring.llm_judge import LLMJudgeScorer
-        
+
         item = EvaluationItem(
             id="1",
             input="What is the capital of France?",
             output="Paris is the capital of France.",
-            expected_output="Paris"
+            expected_output="Paris",
         )
-        
+
         config = {
             "provider": "openai",
             "model": "gpt-3.5-turbo",
             "temperature": 0.3,
             "api_key": os.getenv("OPENAI_API_KEY"),  # This would need a real key
         }
-        
+
         scorer = LLMJudgeScorer(config)
         result = await scorer.score(item)
-        
+
         assert result.score >= 0.0 and result.score <= 1.0
         assert isinstance(result.passed, bool)
         assert result.reasoning is not None
@@ -306,11 +308,11 @@ class TestEndToEndEvaluation:
         """Test creating LLM clients with real API keys."""
         # This test would validate real API keys
         from services.llm_clients import create_llm_client
-        
+
         # Test OpenAI client
         client = create_llm_client("openai", os.getenv("OPENAI_API_KEY"))
         assert client.validate_api_key()
-        
+
         # Test Anthropic client
         client = create_llm_client("anthropic", os.getenv("ANTHROPIC_API_KEY"))
         assert client.validate_api_key()
@@ -318,17 +320,19 @@ class TestEndToEndEvaluation:
 
 class TestErrorHandling:
     """Test error handling in the evaluation pipeline."""
-    
+
     def test_load_invalid_csv(self):
         """Test loading CSV with missing columns."""
-        df = pd.DataFrame({
-            "input": ["Q1", "Q2"],
-            # Missing expected_output column
-        })
-        
+        df = pd.DataFrame(
+            {
+                "input": ["Q1", "Q2"],
+                # Missing expected_output column
+            }
+        )
+
         with pytest.raises(ValueError, match="Missing required columns"):
             load_evaluation_data(df, EvaluationMode.EVALUATE_EXISTING)
-    
+
     @pytest.mark.asyncio
     async def test_scorer_error_handling(self):
         """Test that scorer errors are handled gracefully."""
@@ -338,34 +342,34 @@ class TestErrorHandling:
                 id="1",
                 input="Test",
                 output=None,  # This will cause issues
-                expected_output="Expected"
+                expected_output="Expected",
             )
         ]
-        
+
         results = await run_evaluation(
             items=items,
             selected_scorers=["exact_match"],
             scorer_configs={},
             api_keys={},
         )
-        
+
         # Should still return results
         assert len(results.items) == 1
         assert len(results.items[0].scores) == 1
         assert results.items[0].scores[0].score == 0.0
         assert not results.items[0].scores[0].passed
-    
+
     def test_invalid_scorer_name(self):
         """Test handling of invalid scorer name."""
         from core.scoring import create_scorer
-        
+
         with pytest.raises(ValueError, match="Unknown scorer"):
             create_scorer("invalid_scorer_name")
 
 
 class TestReporting:
     """Test reporting functionality."""
-    
+
     def test_csv_export_with_metadata(self):
         """Test CSV export includes metadata columns."""
         items = [
@@ -374,48 +378,44 @@ class TestReporting:
                 input="Test",
                 output="Output",
                 expected_output="Expected",
-                metadata={"source": "test", "category": "math"}
+                metadata={"source": "test", "category": "math"},
             )
         ]
-        
+
         results = EvaluationResults(items=items, config={}, metadata={})
         csv_content = results_to_csv(results)
-        
+
         assert "metadata_source" in csv_content
         assert "metadata_category" in csv_content
         assert "test" in csv_content
         assert "math" in csv_content
-    
+
     def test_json_export_structure(self):
         """Test JSON export has correct structure."""
         items = [
             EvaluationItem(
-                id="1",
-                input="Test",
-                output="Output",
-                expected_output="Expected"
+                id="1", input="Test", output="Output", expected_output="Expected"
             )
         ]
-        
+
         from core.data_models import ScorerResult
+
         items[0].scores.append(
             ScorerResult(
                 scorer_name="test_scorer",
                 score=0.5,
                 passed=False,
                 reasoning="Test reasoning",
-                details={"extra": "info"}
+                details={"extra": "info"},
             )
         )
-        
+
         results = EvaluationResults(
-            items=items,
-            config={"test": "config"},
-            metadata={"test": "metadata"}
+            items=items, config={"test": "config"}, metadata={"test": "metadata"}
         )
-        
+
         json_data = json.loads(results_to_json(results))
-        
+
         assert json_data["items"][0]["id"] == "1"
         assert json_data["items"][0]["scores"][0]["scorer_name"] == "test_scorer"
         assert json_data["items"][0]["scores"][0]["score"] == 0.5

--- a/tests/unit/test_exact_match.py
+++ b/tests/unit/test_exact_match.py
@@ -1,6 +1,7 @@
 """
 Unit tests for exact match scorer.
 """
+
 import pytest
 from core.data_models import EvaluationItem, ScorerResult
 from core.scoring.exact_match import (
@@ -12,78 +13,62 @@ from core.scoring.exact_match import (
 
 class TestExactMatchScorer:
     """Test cases for ExactMatchScorer."""
-    
+
     def test_exact_match_success(self):
         """Test exact match when strings are identical."""
         scorer = ExactMatchScorer()
-        item = EvaluationItem(
-            input="What is 2+2?",
-            output="4",
-            expected_output="4"
-        )
-        
+        item = EvaluationItem(input="What is 2+2?", output="4", expected_output="4")
+
         result = scorer.score(item)
-        
+
         assert isinstance(result, ScorerResult)
         assert result.score == 1.0
         assert result.passed is True
         assert "Exact match found" in result.reasoning
-    
+
     def test_exact_match_failure(self):
         """Test exact match when strings differ."""
         scorer = ExactMatchScorer()
-        item = EvaluationItem(
-            input="What is 2+2?",
-            output="Four",
-            expected_output="4"
-        )
-        
+        item = EvaluationItem(input="What is 2+2?", output="Four", expected_output="4")
+
         result = scorer.score(item)
-        
+
         assert result.score == 0.0
         assert result.passed is False
         assert "does not exactly match" in result.reasoning
-    
+
     def test_exact_match_whitespace_handling(self):
         """Test that whitespace is stripped before comparison."""
         scorer = ExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="  Hello World  ",
-            expected_output="Hello World"
+            input="Test", output="  Hello World  ", expected_output="Hello World"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_exact_match_no_output(self):
         """Test handling when output is None."""
         scorer = ExactMatchScorer()
-        item = EvaluationItem(
-            input="Test",
-            output=None,
-            expected_output="Expected"
-        )
-        
+        item = EvaluationItem(input="Test", output=None, expected_output="Expected")
+
         result = scorer.score(item)
-        
+
         assert result.score == 0.0
         assert result.passed is False
         assert "No output provided" in result.reasoning
-    
+
     def test_exact_match_includes_details(self):
         """Test that result includes helpful details."""
         scorer = ExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="Hello",
-            expected_output="Hello World"
+            input="Test", output="Hello", expected_output="Hello World"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.details["output_length"] == 5
         assert result.details["expected_length"] == 11
         assert result.details["stripped_match"] is False
@@ -91,158 +76,152 @@ class TestExactMatchScorer:
 
 class TestCaseInsensitiveExactMatchScorer:
     """Test cases for CaseInsensitiveExactMatchScorer."""
-    
+
     def test_case_insensitive_match(self):
         """Test case-insensitive matching."""
         scorer = CaseInsensitiveExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="HELLO WORLD",
-            expected_output="hello world"
+            input="Test", output="HELLO WORLD", expected_output="hello world"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_case_insensitive_no_match(self):
         """Test case-insensitive non-matching."""
         scorer = CaseInsensitiveExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="HELLO",
-            expected_output="hello world"
+            input="Test", output="HELLO", expected_output="hello world"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 0.0
         assert result.passed is False
-    
+
     def test_details_include_case_sensitive_info(self):
         """Test that details show both case-sensitive and insensitive results."""
         scorer = CaseInsensitiveExactMatchScorer()
-        item = EvaluationItem(
-            input="Test",
-            output="Hello",
-            expected_output="HELLO"
-        )
-        
+        item = EvaluationItem(input="Test", output="Hello", expected_output="HELLO")
+
         result = scorer.score(item)
-        
+
         assert result.details["case_sensitive_match"] is False
         assert result.details["case_insensitive_match"] is True
 
 
 class TestNormalizedExactMatchScorer:
     """Test cases for NormalizedExactMatchScorer."""
-    
+
     def test_normalization_whitespace(self):
         """Test whitespace normalization."""
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
             input="Test",
             output="Hello    World",  # Multiple spaces
-            expected_output="hello world"      # Single space
+            expected_output="hello world",  # Single space
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_normalization_smart_quotes(self):
         """Test smart quote normalization."""
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
             input="Test",
             output="\u201cHello World\u201d",  # Smart quotes
-            expected_output='"Hello World"'    # Regular quotes
+            expected_output='"Hello World"',  # Regular quotes
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_normalization_apostrophes(self):
         """Test smart apostrophe normalization."""
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
             input="Test",
-            output="It\u2019s working",     # Smart apostrophe
-            expected_output="It's working"  # Regular apostrophe
+            output="It\u2019s working",  # Smart apostrophe
+            expected_output="It's working",  # Regular apostrophe
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_ignore_trailing_punctuation_config(self):
         """Test configuration to ignore trailing punctuation."""
         scorer = NormalizedExactMatchScorer({"ignore_trailing_punctuation": True})
         item = EvaluationItem(
-            input="Test",
-            output="Hello World!",
-            expected_output="Hello World"
+            input="Test", output="Hello World!", expected_output="Hello World"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 1.0
         assert result.passed is True
-    
+
     def test_keep_trailing_punctuation_default(self):
         """Test that trailing punctuation is kept by default."""
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="Hello World!",
-            expected_output="Hello World"
+            input="Test", output="Hello World!", expected_output="Hello World"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.score == 0.0
         assert result.passed is False
-    
+
     def test_details_show_normalized_values(self):
         """Test that details include normalized values."""
         scorer = NormalizedExactMatchScorer()
         item = EvaluationItem(
-            input="Test",
-            output="HELLO   WORLD",
-            expected_output="hello world"
+            input="Test", output="HELLO   WORLD", expected_output="hello world"
         )
-        
+
         result = scorer.score(item)
-        
+
         assert result.details["normalized_output"] == "hello world"
         assert result.details["normalized_expected"] == "hello world"
         assert result.details["raw_match"] is False
 
 
-@pytest.mark.parametrize("output,expected,should_match", [
-    ("Hello", "Hello", True),
-    ("Hello ", " Hello", True),
-    ("HELLO", "hello", False),
-    ("Hello!", "Hello", False),
-    ("", "", True),
-    ("  ", "", True),
-])
+@pytest.mark.parametrize(
+    "output,expected,should_match",
+    [
+        ("Hello", "Hello", True),
+        ("Hello ", " Hello", True),
+        ("HELLO", "hello", False),
+        ("Hello!", "Hello", False),
+        ("", "", True),
+        ("  ", "", True),
+    ],
+)
 def test_exact_match_parametrized(output, expected, should_match):
     """Parametrized tests for exact match scorer."""
     scorer = ExactMatchScorer()
+    if not expected.strip() and not output.strip():
+        with pytest.raises(ValueError):
+            EvaluationItem(input="Test", output=output, expected_output=expected)
+        return
+
     item = EvaluationItem(
         input="Test",
         output=output,
-        expected_output=expected
+        expected_output=expected,
     )
-    
+
     result = scorer.score(item)
-    
+
     if should_match:
         assert result.score == 1.0
         assert result.passed is True


### PR DESCRIPTION
## Summary
- adjust integration test expectations for bullet-style report
- handle empty input cases in exact match unit tests

## Testing
- `pytest -v -m "not requires_api"`

------
https://chatgpt.com/codex/tasks/task_e_6845284f379083278f69d46600a0712c