### PR TITLE
Re-enable lint and test jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,84 +8,72 @@ on:
   workflow_dispatch:  # Add this to manually trigger
 
 jobs:
-  # Single job to indicate CI is disabled
-  ci-disabled:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: CI Temporarily Disabled
-        run: |
-          echo "CI checks are temporarily disabled while fixing test issues"
-          echo "To re-enable, remove this job and uncomment the jobs below"
+    - uses: actions/checkout@v3
 
-# ALL JOBS BELOW ARE COMMENTED OUT TO DISABLE CI TEMPORARILY
-# Uncomment when ready to re-enable
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
 
-#   lint:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v3
-#     
-#     - name: Set up Python
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: '3.9'
-#     
-#     - name: Install dependencies
-#       run: |
-#         python -m pip install --upgrade pip
-#         pip install black isort flake8 mypy
-#         pip install -r requirements.txt
-#     
-#     - name: Format check with Black
-#       run: black --check .
-#     
-#     - name: Import sort check with isort
-#       run: isort --check-only .
-#     
-#     - name: Lint with flake8
-#       run: |
-#         # Stop build if there are Python syntax errors or undefined names
-#         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-#         # Exit-zero treats all errors as warnings
-#         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-#     
-#     - name: Type check with mypy
-#       run: mypy . --ignore-missing-imports
-# 
-#   test:
-#     runs-on: ubuntu-latest
-#     strategy:
-#       matrix:
-#         python-version: ['3.8', '3.9', '3.10', '3.11']
-#     
-#     steps:
-#     - uses: actions/checkout@v3
-#     
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     
-#     - name: Install dependencies
-#       run: |
-#         python -m pip install --upgrade pip
-#         pip install -r requirements.txt
-#         pip install pytest pytest-asyncio pytest-cov
-#     
-#     - name: Run unit tests
-#       run: |
-#         pytest tests/unit -v --cov=core --cov=services --cov=utils --cov-report=term-missing
-#     
-#     - name: Run integration tests
-#       run: |
-#         pytest tests/integration -v
-#     
-#     - name: Upload coverage reports
-#       uses: codecov/codecov-action@v3
-#       if: matrix.python-version == '3.9'
-#       with:
-#         file: ./coverage.xml
-#         fail_ci_if_error: false
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black isort flake8 mypy
+        pip install -r requirements.txt
+
+    - name: Format check with Black
+      run: black --check .
+
+    - name: Import sort check with isort
+      run: isort --check-only .
+
+    - name: Lint with flake8
+      run: |
+        # Stop build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # Exit-zero treats all errors as warnings
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Type check with mypy
+      run: mypy . --ignore-missing-imports
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-asyncio pytest-cov
+
+    - name: Run unit tests
+      run: |
+        pytest tests/unit -v -m "not requires_api" --cov=core --cov-report=term-missing
+
+    - name: Run integration tests
+      run: |
+        pytest tests/integration -v -m "not requires_api"
+
+    - name: Upload coverage reports
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == '3.9'
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false
 # 
 #   build:
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable lint and test jobs in the workflow
- test against Python 3.9–3.11
- skip API-dependent tests

## Testing
- `pytest -v -m "not requires_api"`

------
https://chatgpt.com/codex/tasks/task_e_684f258e4bb0832790f414bf3a94a1d7