### PR TITLE
Fix Streamlit deployment: Add missing otel packages to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ dev = [
 # list here from the [project] section above. This is where
 # setuptools expects to find it.
 [tool.setuptools]
-packages = ["app", "core", "services", "utils"]
+packages = ["app", "core", "core.otel", "core.scoring", "core.scoring.otel", "services", "utils"]


### PR DESCRIPTION
The deployment was failing because the new core.otel and core.scoring.otel packages were not listed in the [tool.setuptools] packages array. Streamlit Community Cloud needs all packages explicitly listed for proper installation.

🤖 Generated with [Claude Code](https://claude.ai/code)