### PR TITLE
Fix: Revert pyproject.toml packages to original working format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ dev = [
 # list here from the [project] section above. This is where
 # setuptools expects to find it.
 [tool.setuptools]
-packages = ["app", "core", "core.otel", "core.scoring", "core.scoring.otel", "services", "utils"]
+packages = ["app", "core", "services", "utils"]


### PR DESCRIPTION
The issue was that we explicitly listed subdirectories like 'core.otel' when 'core' already includes all its subdirectories. This was causing conflicts in Streamlit Community Cloud deployment.

Reverted to original format that only lists top-level packages.

🤖 Generated with [Claude Code](https://claude.ai/code)